### PR TITLE
Update sqlite3 dependency version and python package name so image can be built.

### DIFF
--- a/fullstack-notes-application/api/Dockerfile
+++ b/fullstack-notes-application/api/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:lts-alpine as builder
 
 # install dependencies for node-gyp
-RUN apk add --no-cache python make g++
+RUN apk add --no-cache python2 make g++
 
 WORKDIR /app
 

--- a/fullstack-notes-application/api/Dockerfile.dev
+++ b/fullstack-notes-application/api/Dockerfile.dev
@@ -2,7 +2,7 @@
 FROM node:lts-alpine as builder
 
 # install dependencies for node-gyp
-RUN apk add --no-cache python make g++
+RUN apk add --no-cache python2 make g++
 
 WORKDIR /app
 

--- a/fullstack-notes-application/api/package.json
+++ b/fullstack-notes-application/api/package.json
@@ -37,7 +37,7 @@
     "lint-staged": "^10.1.7",
     "nodemon": "^2.0.3",
     "prettier": "^2.0.5",
-    "sqlite3": "^4.2.0",
+    "sqlite3": "^5.0.0",
     "supertest": "^4.0.2"
   },
   "lint-staged": {

--- a/notes-api/api/package.json
+++ b/notes-api/api/package.json
@@ -33,7 +33,7 @@
     "lint-staged": "^10.1.7",
     "nodemon": "^2.0.3",
     "prettier": "^2.0.5",
-    "sqlite3": "^4.2.0",
+    "sqlite3": "^5.0.0",
     "supertest": "^4.0.2"
   },
   "lint-staged": {


### PR DESCRIPTION
Updates sqlite3 dependency version to 5.0.0 in notes-api so docker image can be built. Without this the command `docker image build --tag notes-api .` from the [Containerizing A Multi Container JavaScript Application](https://docker-handbook.farhan.dev/containerizing-a-multi-container-javascript-application#writing-the-dockerfile) section of the handbook fails.

Also updates the sqlite3 version and python package name in the fullstack app so the build script completes without errors.